### PR TITLE
Fix tortoise throwing a TypeError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ uvloop
 parsedatetime
 pytz
 discord.py[voice]
-tortoise-orm
+tortoise-orm==0.16.3
 python-rapidjson
 ciso8601
 pydantic


### PR DESCRIPTION
Force version 0.16.3 of tortoise-orm which was the version used during the event (later versions may work, untested).